### PR TITLE
HuddleTypes Consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ $ yarn add huddle01-client
 
 2. **Get your API Key:** You can get your access keys in the Developer section of the Huddle01 Dashboard
 
-3. **Import modules & instantiate Huddle01 Client:**
+3. **Import modules & instantiate Huddle01 Client. Also import the HuddleTypes and HuddleClientConfig to access the types**
 
 ```typescript
-import HuddleClient, { emitter } from "huddle01-client";
+import HuddleClient, { emitter, HuddleTypes, HuddleClientConfig, } from "huddle01-client";
 ```
 
 **The infrastructure mandates a schema on the URL** of the type `https://domain.com/room?roomId=C132`
@@ -33,34 +33,12 @@ history.push(`?roomId=${config.roomId}`);
 Initialise a new object
 
 ```typescript
-const huddle: IHuddleClientConfig = new HuddleClient(config);
+const huddle: HuddleClient = new HuddleClient(config);
 ```
 
-where `config` is of type `IHuddleClientConfig` (provided in the interface directory) given as
+where `config` is of type `HuddleClientConfig` which is exported from the npm package.
 
-```typescript
-interface IHuddleClientConfig {
-  roomId: string;
-  peerId: string;
-  apiKey: string;
-  displayName: string;
-  handlerName?: string;
-  useSimulcast?: boolean;
-  useSharingSimulcast?: boolean;
-  forceTcp?: boolean;
-  produce?: boolean;
-  consume?: boolean;
-  forceH264?: boolean;
-  forceVP9?: boolean;
-  svc?: any;
-  datachannel?: boolean;
-  externalVideo?: any;
-  isBot: boolean;
-  userToken?: string;
-  userPassword?: string;
-  window: Window;
-}
-```
+Along with this, `HuddleTypes` containing types for Producer, Consumer and Peer are also exported from the npm package.
 
 An example `config` object can be given as
 
@@ -68,7 +46,7 @@ An example `config` object can be given as
 //write this as it is -- used to check for the recorder
 const isRecorderBot = localStorage.getItem("bot_password") === "huddle01";
 
-const config: IHuddleClientConfig = {
+const config: HuddleClientConfig = {
   apiKey: "<API Key>",          // API KEY (issued on the dashboard)
   roomId: "C132",               // Room ID
   peerId: "rick254",            // Peer ID (needs to be unique for every peer)
@@ -124,27 +102,19 @@ The emitter that we imported in the 1st step is used to emit events by Huddle ab
     ```
 
 3. **Trigger:** new peer joins the room  
-**Return value:** an entire peer object with all the details about the peer of the type `protooClient.Peer`
+**Return value:** an entire peer object with all the details about the peer of the type `HuddleTypes.IPeer`
 
     ```typescript
-    emitter.on("addPeer", (peer: Peer) => {
+    emitter.on("addPeer", (peer: IPeer) => {
       //do whatever
     });
     ```
 
 4. **Trigger:** you have a new producer producing to the Huddle servers  
-**Return value:** an producer object with details like your production media track \(eg. webcam/mic/screenshare\) of the type `object`
-
-    The `Producer` type extends the `Mediasoup Producer` and is given as
+**Return value:** an producer object with details like your production media track \(eg. webcam/mic/screenshare\) of the type `HuddleTypes.IProducer`.
 
     ```typescript
-    interface IProducer extends MediaSoupClient.types.Producer {
-      type?: string;
-    }
-    ```
-
-    ```typescript
-    emitter.on("addProducer", (producer: Producer) => {
+    emitter.on("addProducer", (producer: IProducer) => {
       //do whatever (ideally switch-case between all state types)
     });
     ```
@@ -158,18 +128,11 @@ The emitter that we imported in the 1st step is used to emit events by Huddle ab
     | a webcam stream consumer | a mic stream consumer | a screenshare stream consumer |
 
 5. **Trigger:** you have a new consumer consuming from the Huddle servers  
-**Return value:** a consumer object with details like your consumption media track \(eg. webcam/mic/screenshare\) of the type `object`
+**Return value:** a consumer object with details like your consumption media track \(eg. webcam/mic/screenshare\) of the type `HuddleTypes.IConsumer`
 
-    The `Consumer` type extends the `Mediasoup Conusumer` and is given as
-
-    ```typescript
-    interface IConsumer extends MediaSoupClient.types.Consumer {
-      type?: string;
-    }
-    ```
 
     ```typescript
-    emitter.on("addConsumer", (consumer: any) => {
+    emitter.on("addConsumer", (consumer: IConsumer) => {
       //do whatever (ideally switch-case between all state types)
     });
     ```
@@ -183,19 +146,19 @@ The emitter that we imported in the 1st step is used to emit events by Huddle ab
     | a webcam stream consumer | a mic stream consumer | a screenshare stream consumer |
 
 6. **Trigger:** one of the existing peers disconnects from the room  
-**Return value:** an entire peer object with all the details about the peer of the type `object`\(same as the object received on the "add" event\)
+**Return value:** an entire peer object with all the details about the peer of the type `HuddleTypes.IPeer`\(same as the object received on the "add" event\)
 
     ```typescript
-    emitter.on("removePeer", (peer: any) => {
+    emitter.on("removePeer", (peer: IPeer) => {
       //do whatever
     });
     ```
 
 7. **Trigger:** you have closed the production of your existing producer to the Huddle servers  
-**Return value:** a producer object with details like your production media track \(eg. webcam/mic/screenshare\) peer of the type `object` \(same as the object received on the "add" event\)
+**Return value:** a producer object with details like your production media track \(eg. webcam/mic/screenshare\) peer of the type `HuddleTypes.IProducer` \(same as the object received on the "add" event\)
 
     ```typescript
-    emitter.on("removeProducer", (producer: Producer) => {
+    emitter.on("removeProducer", (producer: IProducer) => {
       //do whatever (ideally switch-case between all state types)
     });
     ```
@@ -208,10 +171,10 @@ The emitter that we imported in the 1st step is used to emit events by Huddle ab
     | a webcam stream producer | a mic stream producer | a screenshare stream producer |
 
 8. **Trigger:** you have closed the production of your existing producer to the Huddle servers  
-**Return value:** a consumer object with details like your consumption media track \(eg. webcam/mic/screenshare\) peer of the type `object` \(same as the object received on the "add" event\)
+**Return value:** a consumer object with details like your consumption media track \(eg. webcam/mic/screenshare\) peer of the type `HuddleTypes.IConsumer` \(same as the object received on the "add" event\)
 
     ```typescript
-    emitter.on("removeConsumer", (consumer: any) => {
+    emitter.on("removeConsumer", (consumer: IConsumer) => {
       //do whatever (ideally switch-case between all state types)
     });
     ```

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "axios": "^0.21.1",
     "events": "^3.3.0",
     "huddle01-client": "^1.1.2",
-    "mediasoup-client": "^3.6.31",
-    "protoo-client": "^4.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
@@ -19,7 +17,6 @@
   },
   "devDependencies": {
     "@types/node": "^16.3.3",
-    "@types/protoo-client": "^4.0.1",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",

--- a/src/containers/Room.tsx
+++ b/src/containers/Room.tsx
@@ -1,8 +1,9 @@
 //client sdk import
-import HuddleClient, { emitter } from "huddle01-client";
-
-// Peer class
-import { Peer } from "protoo-client";
+import HuddleClient, {
+  emitter,
+  HuddleTypes,
+  HuddleClientConfig,
+} from "huddle01-client";
 
 //react imports
 import { useEffect, useState, useRef } from "react";
@@ -13,12 +14,7 @@ import { getTrack } from "../lib/utils/helpers";
 import { PeerVideo, PeerAudio, PeerScreen } from "../components/PeerViewport";
 
 // interfaces
-import {
-  IConsumer,
-  IProducer,
-  IConsumerStreams,
-  IHuddleClientConfig,
-} from "../interface/interfaces";
+import { IConsumerStreams } from "../interface/interfaces";
 
 function Room() {
   const history = useHistory();
@@ -31,7 +27,7 @@ function Room() {
   const [webcamState, setWebcamState] = useState<boolean>(false);
   const [screenshareState, setScreenshareState] = useState<boolean>(false);
 
-  const [peers, setPeers] = useState<Peer[]>([]);
+  const [peers, setPeers] = useState<HuddleTypes.IPeer[]>([]);
   const [consumerStreams, setConsumerStreams] = useState<IConsumerStreams>({
     video: [],
     audio: [],
@@ -42,7 +38,7 @@ function Room() {
   const meScreenElem = useRef<any>(null);
   const joinRoomBtn = useRef<any>(null);
 
-  const config: IHuddleClientConfig = {
+  const config: HuddleClientConfig = {
     apiKey: "ASGDkYhPwLi7wHecVIeD5vT64jKt8di70o9Z2LP5",
     roomId: "C132",
     peerId: "Rick" + Math.floor(Math.random() * 4000),
@@ -89,12 +85,12 @@ function Room() {
       //do whatever
     });
 
-    emitter.on("addPeer", (peer: Peer) => {
+    emitter.on("addPeer", (peer: HuddleTypes.IPeer) => {
       console.log("new peer =>", peer);
       setPeers((_peers) => [..._peers, peer]);
     });
 
-    emitter.on("addProducer", (producer: IProducer) => {
+    emitter.on("addProducer", (producer: HuddleTypes.IProducer) => {
       console.log("new prod", producer);
       switch (producer.type) {
         case "webcam":
@@ -130,7 +126,7 @@ function Room() {
       }
     });
 
-    emitter.on("removeProducer", (producer: IProducer) => {
+    emitter.on("removeProducer", (producer: HuddleTypes.IProducer) => {
       console.log("remove ", producer);
       switch (producer.type) {
         case "webcam":
@@ -156,7 +152,7 @@ function Room() {
       }
     });
 
-    emitter.on("addConsumer", (consumer: IConsumer) => {
+    emitter.on("addConsumer", (consumer: HuddleTypes.IConsumer) => {
       switch (consumer.type) {
         case "webcam": {
           const videoStream = consumer.track;

--- a/src/interface/interfaces.ts
+++ b/src/interface/interfaces.ts
@@ -1,37 +1,5 @@
-import { types as MediasoupTypes } from "mediasoup-client"
-
 export interface IConsumerStreams {
     video: MediaStreamTrack[];
     audio: MediaStreamTrack[];
     screen: MediaStreamTrack[];
-}
-
-export interface IProducer extends MediasoupTypes.Producer {
-    type?: string;
-}
-
-export interface IConsumer extends MediasoupTypes.Consumer {
-    type?: string;
-}
-
-export interface IHuddleClientConfig {
-    roomId: string;
-    peerId: string;
-    apiKey: string;
-    displayName: string;
-    handlerName?: string;
-    useSimulcast?: boolean;
-    useSharingSimulcast?: boolean;
-    forceTcp?: boolean;
-    produce?: boolean;
-    consume?: boolean;
-    forceH264?: boolean;
-    forceVP9?: boolean;
-    svc?: any;
-    datachannel?: boolean;
-    externalVideo?: any;
-    isBot: boolean;
-    userToken?: string;
-    userPassword?: string;
-    window: Window;
 }


### PR DESCRIPTION
The client consumes the exported types as `HuddleTypes` from the npm huddle01-client sdk package.